### PR TITLE
fix: Remove deprecated Neovim function (0.10)

### DIFF
--- a/lua/journal/config.lua
+++ b/lua/journal/config.lua
@@ -45,7 +45,7 @@ M.get = function()
 end
 
 local function is_dict_like(tbl)
-    return type(tbl) == 'table' and not vim.tbl_islist(tbl)
+    return type(tbl) == 'table' and not vim.islist(tbl)
 end
 
 local merge_configs = function(user_config, config)


### PR DESCRIPTION
`vim.tbl_islist` is deprecated in Neovim 0.10, it's replaced here with `vim.islist`.